### PR TITLE
[Important][Android] Fix crash null target view when use with react-native-navigation MODAL

### DIFF
--- a/android/src/main/java/ui/apptour/RNAppTourModule.java
+++ b/android/src/main/java/ui/apptour/RNAppTourModule.java
@@ -7,6 +7,13 @@ import android.content.res.Resources;
 import android.graphics.Color;
 import android.util.Log;
 import android.support.annotation.Nullable;
+import android.app.Dialog;
+import android.view.View;
+import android.app.AlertDialog;
+
+import com.facebook.react.uimanager.UIManagerModule;
+import com.facebook.react.uimanager.UIBlock;
+import com.facebook.react.uimanager.NativeViewHierarchyManager;
 
 import com.facebook.common.internal.Objects;
 import com.facebook.react.bridge.Promise;

--- a/android/src/main/java/ui/apptour/RNAppTourModule.java
+++ b/android/src/main/java/ui/apptour/RNAppTourModule.java
@@ -1,4 +1,3 @@
-
 package ui.apptour;
 
 import android.app.Activity;
@@ -86,7 +85,6 @@ public class RNAppTourModule extends ReactContextBaseJavaModule {
                             sendEvent(reactContext, "onFinishSequenceEvent", params);
                             // dismiss dialog on finish
                             if(dialog != null && dialog.isShowing()) {
-                              Log.d("SmartSOS", "Dismiss Dialog 1111111");
                                dialog.dismiss();
                             }
                         }

--- a/android/src/main/java/ui/apptour/RNAppTourModule.java
+++ b/android/src/main/java/ui/apptour/RNAppTourModule.java
@@ -63,26 +63,33 @@ public class RNAppTourModule extends ReactContextBaseJavaModule {
   public void ShowSequence(final ReadableArray views, final ReadableMap props, final Promise promise) {
       final Activity activity = this.getCurrentActivity();
       final List<TapTarget> targetViews = new ArrayList<TapTarget>();
+
       final Dialog dialog = new AlertDialog.Builder(activity).create();
+
       activity.runOnUiThread(new Runnable() {
           @Override
           public void run() {
             UIManagerModule uiManager = reactContext.getNativeModule(UIManagerModule.class);
+
             uiManager.addUIBlock(new UIBlock() {
                 @Override
                 public void execute(NativeViewHierarchyManager nativeViewHierarchyManager) {
                     for (int i = 0;i < views.size();i++) {
                         int view = views.getInt(i);
+
                         View refView = nativeViewHierarchyManager.resolveView(view);
                         targetViews.add(generateTapTarget(refView, props.getMap(String.valueOf(view))));
                     }
+
                     TapTargetSequence tapTargetSequence = new TapTargetSequence(dialog).targets(targetViews);
                     tapTargetSequence.listener(new TapTargetSequence.Listener() {
                         @Override
                         public void onSequenceFinish() {
                             WritableMap params = Arguments.createMap();
                             params.putBoolean("finish", true);
+
                             sendEvent(reactContext, "onFinishSequenceEvent", params);
+
                             // dismiss dialog on finish
                             if(dialog != null && dialog.isShowing()) {
                                dialog.dismiss();
@@ -93,6 +100,7 @@ public class RNAppTourModule extends ReactContextBaseJavaModule {
                         public void onSequenceStep(TapTarget lastTarget, boolean targetClicked) {
                             WritableMap params = Arguments.createMap();
                             params.putBoolean("next_step", true);
+
                             sendEvent(reactContext, "onShowSequenceStepEvent", params);
                         }
 
@@ -100,6 +108,7 @@ public class RNAppTourModule extends ReactContextBaseJavaModule {
                         public void onSequenceCanceled(TapTarget lastTarget) {
                             WritableMap params = Arguments.createMap();
                             params.putBoolean("cancel_step", true);
+
                             sendEvent(reactContext, "onCancelStepEvent", params);
                         }
                     })
@@ -115,15 +124,18 @@ public class RNAppTourModule extends ReactContextBaseJavaModule {
   public void ShowFor(final int view, final ReadableMap props, final Promise promise) {
       final Activity activity = this.getCurrentActivity();
       final Dialog dialog = new AlertDialog.Builder(activity).create();
+
       activity.runOnUiThread(new Runnable() {
           @Override
           public void run() {
             UIManagerModule uiManager = reactContext.getNativeModule(UIManagerModule.class);
+
             uiManager.addUIBlock(new UIBlock() {
                 @Override
                 public void execute(NativeViewHierarchyManager nativeViewHierarchyManager) {
                     View refView = nativeViewHierarchyManager.resolveView(view);
                     TapTarget targetView = generateTapTarget(refView, props);
+
                     TapTargetView.showFor(dialog, targetView);
                 }
             });


### PR DESCRIPTION
[ANDROID]
- Now no error with tutorial pop up behind show behind modal with react-navigation.
- Can resolve null view reference pass from React native JS to native code.

@prscX this is an important fix for android with crash null view
- Please check & merge it & release if you can 👯‍♂️ 

Thanks,
Cong