### PR TITLE
Prevent multiple addition of same component in the tour

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,8 +140,9 @@ AppTour.ShowSequence(appTourSequence)
 
 > **Note:**
 >
+> * Each component which is to be rendered in the tour should have a "key" prop. It is mandatory.
 > * App Tour Target Properties are same as defined by [KeepSafe/TapTargetView](https://github.com/KeepSafe/TapTargetView) & [aromajoin/material-showcase-ios](https://github.com/aromajoin/material-showcase-ios)
-> * Each component which is to be rendered in the tour should have a unique "key" prop mandatorily.
+
 
 
 ## Breaking Changes

--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ AppTour.ShowSequence(appTourSequence)
 > **Note:**
 >
 > * App Tour Target Properties are same as defined by [KeepSafe/TapTargetView](https://github.com/KeepSafe/TapTargetView) & [aromajoin/material-showcase-ios](https://github.com/aromajoin/material-showcase-ios)
+> * Each component which is to be rendered in the tour should have a unique "key" prop mandatorily.
 
 
 ## Breaking Changes

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ AppTour.ShowSequence(appTourSequence)
 
 > **Note:**
 >
-> * Each component which is to be rendered in the tour should have a "key" prop. It is mandatory.
+> * Each component which is to be rendered in the tour should have a `key` prop. It is mandatory.
 > * App Tour Target Properties are same as defined by [KeepSafe/TapTargetView](https://github.com/KeepSafe/TapTargetView) & [aromajoin/material-showcase-ios](https://github.com/aromajoin/material-showcase-ios)
 
 

--- a/RNAppTour.js
+++ b/RNAppTour.js
@@ -51,7 +51,8 @@ class AppTourSequence {
 
 class AppTourView {
   static for(view, props) {
-    if (view._reactInternalFiber.key === undefined) throw new Error('Each tour view should have a key prop. Please check the render method')
+    if (view === undefined) throw new Error('Provided tour view reference is undefined, please add a preliminary validation before adding for tour.')
+    if (view._reactInternalFiber.key === undefined) throw new Error('Each tour view should have a key prop. Please check the render method,')
     
     return {
       key: view._reactInternalFiber.key,

--- a/RNAppTour.js
+++ b/RNAppTour.js
@@ -51,6 +51,8 @@ class AppTourSequence {
 
 class AppTourView {
   static for(view, props) {
+    if (view._reactInternalFiber.key === undefined) throw new Error('Each tour view should have a key prop. Please check the render method')
+    
     return {
       key: view._reactInternalFiber.key,
       view: findNodeHandle(view),

--- a/RNAppTour.js
+++ b/RNAppTour.js
@@ -12,7 +12,7 @@ class AppTour {
     appTourTargets &&
       appTourTargets.forEach((appTourTarget, key, appTourTargets) => {
         viewIds.push(appTourTarget.view);
-        props[key] = appTourTarget.props;
+        props[appTourTarget.view] = appTourTarget.props;
       });
 
     RNAppTour.ShowSequence(viewIds, props);
@@ -29,11 +29,11 @@ class AppTourSequence {
   }
 
   add(appTourTarget) {
-    this.appTourTargets.set(appTourTarget.view, appTourTarget);
+    this.appTourTargets.set(appTourTarget.key, appTourTarget);
   }
 
   remove(appTourTarget) {
-    this.appTourTargets.delete(appTourTarget.view);
+    this.appTourTargets.delete(appTourTarget.key);
   }
 
   removeAll() {
@@ -52,6 +52,7 @@ class AppTourSequence {
 class AppTourView {
   static for(view, props) {
     return {
+      key: view._reactInternalFiber.key,
       view: findNodeHandle(view),
       props: props
     };


### PR DESCRIPTION
This will allow a component to appear in show sequence of tour only once, thus maintain consistency during multiple re-renderings or any iterative calls.