### PR TITLE
update dependency configurations

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -34,6 +34,6 @@ repositories {
 
 
 dependencies {
-    compile 'com.facebook.react:react-native:+'
-    compile 'com.getkeepsafe.taptargetview:taptargetview:1.11.0'
+    implementation 'com.facebook.react:react-native:+'
+    implementation 'com.getkeepsafe.taptargetview:taptargetview:1.11.0'
 }


### PR DESCRIPTION
Configuration 'compile' is obsolete and has been replaced with 'implementation' and 'api'.
It will be removed at the end of 2018. For more information see: http://d.android.com/r/tools/update-dependency-configurations.html