### PR TITLE
Add package.json homepage link

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "react-native"
   ],
   "author": "Pranav Raj Singh Chauhan",
+  "homepage": "https://github.com/prscX/react-native-app-tour.git",
   "license": "Apache License",
   "dependencies": {
   },


### PR DESCRIPTION
homepage property in package.json is required for proper podspec work:
from `RNAppTour.podspec`:
```
s.homepage               = package['homepage']
```