### PR TITLE
feat: set configurable textCenterOffset prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ AppTour.ShowSequence(appTourSequence)
 | `aniGoOutDuration`           | `number`            | 1.5          | Specify animation Go Out Duration                          |
 | `aniRippleColor`             | `string: HEX-COLOR` | #FFFFFF      | Specify ripple color                                       |
 | `aniRippleAlpha`             | `number`            | 0.2          | Specify ripple alpha                                       |
+| `textCenterOffset`           | `number`            | 44 + 20      | Specify the offset of the text                             |        
 
 ## 🔧 Breaking Changes
 

--- a/ios/RNAppTour.m
+++ b/ios/RNAppTour.m
@@ -167,6 +167,13 @@ RCT_EXPORT_METHOD(ShowFor:(nonnull NSNumber *)view props:(NSDictionary *)props)
         }
     }
 
+    if ([props objectForKey:@"textCenterOffset"] != nil) {
+        float textCenterOffsetValue = [[props objectForKey:@"textCenterOffset"] floatValue];
+        if (textCenterOffsetValue >= 0) {
+            [materialShowcase setTextCenterOffset: textCenterOffsetValue];
+        }
+    }
+
     if ([props objectForKey:@"cancelable"] != nil) {
         BOOL *cancelable = [[props objectForKey:@"cancelable"] boolValue];
         [materialShowcase setIsTapRecognizerForTargetView: !cancelable];


### PR DESCRIPTION
Added a prop to update `TEXT_CENTER_OFFSET`.
Resolves https://github.com/prscX/react-native-app-tour/issues/18

PR in material-showcase-ios: https://github.com/aromajoin/material-showcase-ios/pull/145